### PR TITLE
feat(auth): 인증 시스템 구현

### DIFF
--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -1,0 +1,76 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { parseJwt } from '../../lib/jwt';
+import { login as apiLogin, logout as apiLogout, refresh } from './api';
+import type { LoginPayload, Member } from './types';
+
+type AuthState = {
+  user: Member | null;
+  isAdmin: boolean;
+  isManager: boolean;
+  loading: boolean;
+  login: (p: LoginPayload) => Promise<void>;
+  logout: () => Promise<void>;
+  restore: () => Promise<void>;
+};
+
+const Ctx = createContext<AuthState | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<Member | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  function memberFromToken(token: string | null): Member | null {
+    if (!token) return null;
+    const claims = parseJwt<any>(token);
+    if (!claims) return null;
+
+    return {
+      id: Number(claims.sub ?? claims.id),
+      email: String(claims.email ?? ''),
+      username: String(claims.username ?? claims.name ?? ''),
+      role: (claims.role ?? 'USER') as Member['role'],
+    };
+  }
+
+  const restore = async () => {
+    try {
+      const token = await refresh();
+      setUser(memberFromToken(token));
+    } catch {
+      setUser(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    restore();
+  }, []);
+
+  const value = useMemo<AuthState>(
+    () => ({
+      user,
+      isAdmin: user?.role === 'ADMIN',
+      isManager: user?.role === 'ADMIN' || user?.role === 'MANAGER',
+      loading,
+      login: async (payload) => {
+        const res = await apiLogin(payload);
+        setUser(res.member ?? memberFromToken(res.accessToken));
+      },
+      logout: async () => {
+        await apiLogout();
+        setUser(null);
+      },
+      restore,
+    }),
+    [user, loading],
+  );
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export const useAuthContext = () => {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error('useAuthContext must be used within AuthProvider');
+  return ctx;
+};

--- a/src/features/auth/OAuthButtons.tsx
+++ b/src/features/auth/OAuthButtons.tsx
@@ -1,0 +1,21 @@
+import { APP_URL, OAUTH2_AUTH_PATH } from '../../static/constants';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL.replace(/\/api$/, '');
+type ProviderId = 'google' | 'naver';
+
+export default function OAuthButtons() {
+  const start = (provider: ProviderId) => {
+    const url = `${API_BASE}${OAUTH2_AUTH_PATH}/${provider}?redirect_uri=${encodeURIComponent(`${APP_URL}/oauth2/redirect`)}`;
+    window.location.href = url;
+  };
+  return (
+    <div className="flex gap-2">
+      <button className="btn btn-outline" onClick={() => start('google')}>
+        Google로 계속
+      </button>
+      <button className="btn btn-outline" onClick={() => start('naver')}>
+        Naver로 계속
+      </button>
+    </div>
+  );
+}

--- a/src/features/auth/api.ts
+++ b/src/features/auth/api.ts
@@ -1,0 +1,19 @@
+import api, { setAccessToken } from '../../lib/axios';
+import type { LoginPayload, LoginResponse } from './types';
+
+export async function login(payload: LoginPayload): Promise<LoginResponse> {
+  const { data } = await api.post<LoginResponse>('/auth/tokens', payload);
+  if (data?.accessToken) setAccessToken(data.accessToken);
+  return data;
+}
+
+export async function logout(): Promise<void> {
+  await api.delete('/auth/tokens');
+  setAccessToken(null);
+}
+
+export async function refresh(): Promise<string | null> {
+  const { data } = await api.put<{ accessToken: string }>('/auth/tokens');
+  if (data?.accessToken) setAccessToken(data.accessToken);
+  return data?.accessToken ?? null;
+}

--- a/src/features/auth/types.ts
+++ b/src/features/auth/types.ts
@@ -1,0 +1,19 @@
+import type { Role } from '../../static/roles';
+
+export interface Member {
+  id: number;
+  email: string;
+  username: string;
+  role: Role;
+  createdAt?: string;
+}
+
+export interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  accessToken: string;
+  member: Member;
+}

--- a/src/pages/OAuthCallback.tsx
+++ b/src/pages/OAuthCallback.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuthContext } from '../features/auth/AuthContext';
+
+export default function OAuthCallback() {
+  const nav = useNavigate();
+  const { restore } = useAuthContext();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        await restore();
+        nav('/'); // 홈(공개 꿈 목록) 또는 /dreams/me 등
+      } catch {
+        nav('/login');
+      }
+    })();
+  }, [nav, restore]);
+
+  return (
+    <div className="h-[60vh] flex items-center justify-center">
+      <span className="loading loading-spinner loading-lg" />
+    </div>
+  );
+}


### PR DESCRIPTION
다음 기능들을 구현:

1. 인증 API 및 타입 정의
- 백엔드와 통신하기 위한 API 함수 구현
- API 통신에 사용될 데이터 타입 정의 
2. 전역 상태 관리
- React Context API를 활용하여 앱 전체에서 사용자 인증 상태를 공유하는 AuthProvider 구현
- 앱이 처음 로드될 때 refreshToken 쿠키를 이용해 자동으로 세션을 복구하는 로직을 포함
- useAuthContext 커스텀 훅을 통해 컴포넌트에서 손쉽게 사용자 정보와 로그인/로그아웃 함수에 접근 가능
3. OAuth 로그인 플로우
- Google, Naver 소셜 로그인 시작하는 버튼 컴포넌트 구현
- 소셜 로그인 성공 후 백엔드로부터 리다이렉션되는 콜백 페이지 구현