### PR TITLE
fix: dream, comment api 버그 수정, ui 수정

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,7 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom';
 import Root from './Root';
 import Home from '../pages/Home';
-import Dreams from '../pages/dreams/Dreams';
 import Login from '../pages/auth/Login';
 import Signup from '../pages/auth/Signup';
 import OAuthCallback from '../pages/auth/OAuthCallback';
@@ -13,6 +12,8 @@ import AdminDreams from '../pages/admin/AdminDreams';
 import Members from '../pages/admin/Members';
 import MemberDetail from '../pages/admin/MemberDetail';
 import Protected from '../components/Protected';
+import AdminDreamDetail from '../pages/admin/AdminDreamDetail';
+import Dreams from '../pages/dreams/Dreams.tsx';
 
 export const router = createBrowserRouter([
   {
@@ -20,7 +21,6 @@ export const router = createBrowserRouter([
     element: <Root />,
     children: [
       { index: true, element: <Home /> },
-      { path: 'dreams', element: <Dreams /> },
       { path: 'login', element: <Login /> },
       { path: 'signup', element: <Signup /> },
       { path: 'auth/callback', element: <OAuthCallback /> },
@@ -29,6 +29,7 @@ export const router = createBrowserRouter([
         element: <Protected />,
         children: [
           { path: 'me', element: <Profile /> },
+          { path: 'dreams', element: <Dreams /> },
           { path: 'dreams/me', element: <MyDreams /> },
           { path: 'dreams/new', element: <DreamEditor mode="create" /> },
           { path: 'dreams/:id', element: <DreamDetail /> },
@@ -38,7 +39,10 @@ export const router = createBrowserRouter([
 
       {
         element: <Protected role="MANAGER" />,
-        children: [{ path: 'admin/dreams', element: <AdminDreams /> }],
+        children: [
+          { path: 'admin/dreams', element: <AdminDreams /> },
+          { path: 'admin/dreams/:id', element: <AdminDreamDetail /> },
+        ],
       },
 
       {

--- a/src/components/CommentForm.tsx
+++ b/src/components/CommentForm.tsx
@@ -1,18 +1,32 @@
-import { useState } from 'react';
-import { createComment } from '../features/comments/api';
+import { useEffect, useState } from 'react';
+import { createComment, updateComment } from '../features/comments/api';
 import { useAuthContext } from '../features/auth/AuthContext';
 
 interface Props {
   dreamId: number;
   onSuccess: () => void;
   parentId?: number;
+  mode?: 'create' | 'edit';
+  commentId?: number;
+  initialContent?: string;
 }
 
-export default function CommentForm({ dreamId, onSuccess, parentId }: Props) {
+export default function CommentForm({
+  dreamId,
+  onSuccess,
+  parentId,
+  mode = 'create',
+  commentId,
+  initialContent = '',
+}: Props) {
   const { user } = useAuthContext();
-  const [content, setContent] = useState('');
+  const [content, setContent] = useState(initialContent);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setContent(initialContent);
+  }, [initialContent]);
 
   if (!user) {
     return (
@@ -27,11 +41,21 @@ export default function CommentForm({ dreamId, onSuccess, parentId }: Props) {
     try {
       setLoading(true);
       setError(null);
-      await createComment(dreamId, content);
-      setContent('');
+
+      if (mode === 'create') {
+        await createComment(dreamId, content, parentId);
+        setContent('');
+      } else if (mode === 'edit' && commentId) {
+        await updateComment(commentId, { content });
+      }
+
       onSuccess();
     } catch {
-      setError('댓글 작성에 실패했습니다.');
+      setError(
+        mode === 'create'
+          ? '댓글 작성에 실패했습니다.'
+          : '댓글 수정에 실패했습니다.',
+      );
     } finally {
       setLoading(false);
     }
@@ -51,7 +75,13 @@ export default function CommentForm({ dreamId, onSuccess, parentId }: Props) {
         className="btn btn-primary btn-sm"
         disabled={loading || !content.trim()}
       >
-        {loading ? '작성 중...' : '작성'}
+        {loading
+          ? mode === 'create'
+            ? '작성 중...'
+            : '수정 중...'
+          : mode === 'create'
+            ? '작성'
+            : '수정'}
       </button>
       {error && <p className="text-red-500 text-sm mt-1">{error}</p>}
     </form>

--- a/src/components/CommentForm.tsx
+++ b/src/components/CommentForm.tsx
@@ -5,9 +5,10 @@ import { useAuthContext } from '../features/auth/AuthContext';
 interface Props {
   dreamId: number;
   onSuccess: () => void;
+  parentId?: number;
 }
 
-export default function CommentForm({ dreamId, onSuccess }: Props) {
+export default function CommentForm({ dreamId, onSuccess, parentId }: Props) {
   const { user } = useAuthContext();
   const [content, setContent] = useState('');
   const [loading, setLoading] = useState(false);
@@ -37,16 +38,19 @@ export default function CommentForm({ dreamId, onSuccess }: Props) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="mt-4 flex gap-2">
+    <form onSubmit={handleSubmit} className="mt-2 flex gap-2">
       <input
         type="text"
         value={content}
         onChange={(e) => setContent(e.target.value)}
-        placeholder="댓글을 입력하세요..."
+        placeholder={parentId ? '답글을 입력하세요...' : '댓글을 입력하세요...'}
         className="input input-bordered flex-1"
         disabled={loading}
       />
-      <button className="btn btn-primary" disabled={loading || !content.trim()}>
+      <button
+        className="btn btn-primary btn-sm"
+        disabled={loading || !content.trim()}
+      >
         {loading ? '작성 중...' : '작성'}
       </button>
       {error && <p className="text-red-500 text-sm mt-1">{error}</p>}

--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -175,7 +175,7 @@ export default function CommentList({ dreamId }: Props) {
 
                 {canReply && (
                   <button
-                    className="ml-0 mt-2 text-blue-500 text-sm"
+                    className="ml-0 mt-2 text-blue-500 text-sm btn btn-xs"
                     onClick={() =>
                       setShowReplyInput((prev) => ({
                         ...prev,

--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -102,8 +102,9 @@ export default function CommentList({ dreamId }: Props) {
       ) : (
         <ul className="space-y-3">
           {comments.map((comment) => {
+            console.log(user?.username + ' = ' + comment.author.username);
             const canDelete =
-              user?.username === comment.author ||
+              user?.id === comment.author.id ||
               user?.role === 'ADMIN' ||
               user?.role === 'MANAGER';
             const canReply = user && !comment.isDeleted;
@@ -114,7 +115,7 @@ export default function CommentList({ dreamId }: Props) {
                   <div>
                     <p className="text-sm">{comment.content}</p>
                     <p className="text-xs text-gray-400">
-                      {comment.author} |{' '}
+                      {comment.author.username} |{' '}
                       {new Date(comment.createdAt).toLocaleString()}
                       {comment.isDeleted && canDelete && ' (삭제됨)'}
                     </p>
@@ -174,7 +175,7 @@ export default function CommentList({ dreamId }: Props) {
                   >
                     <p className="text-sm">{reply.content}</p>
                     <p className="text-xs text-gray-400">
-                      {reply.author} |{' '}
+                      {reply.author.username} |{' '}
                       {new Date(reply.createdAt).toLocaleString()}
                       {reply.isDeleted && canDelete && ' (삭제됨)'}
                     </p>

--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from 'react';
-import { deleteComment, getComments } from '../features/comments/api';
+import {
+  createComment,
+  deleteComment,
+  deleteCommentByAdmin,
+  getComments,
+  getReplies,
+} from '../features/comments/api';
 import type { Comment } from '../features/comments/types';
 import Pagination from './ui/Pagination';
 import { useAuthContext } from '../features/auth/AuthContext';
@@ -14,6 +20,18 @@ export default function CommentList({ dreamId }: Props) {
   const [page, setPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [replyContent, setReplyContent] = useState<{ [key: number]: string }>(
+    {},
+  );
+  const [replies, setReplies] = useState<{ [key: number]: Comment[] }>({});
+  const [replyPage, setReplyPage] = useState<{ [key: number]: number }>({});
+  const [replyTotal, setReplyTotal] = useState<{ [key: number]: number }>({});
+  const [loadingReplies, setLoadingReplies] = useState<{
+    [key: number]: boolean;
+  }>({});
+  const [showReplyInput, setShowReplyInput] = useState<{
+    [key: number]: boolean;
+  }>({});
 
   const fetchComments = () => {
     setLoading(true);
@@ -21,19 +39,56 @@ export default function CommentList({ dreamId }: Props) {
       .then((res) => {
         setComments(res.content);
         setTotalPages(res.totalPages);
+
+        res.content.forEach((comment) => {
+          fetchReplies(comment.id, true);
+        });
       })
       .finally(() => setLoading(false));
+  };
+
+  const fetchReplies = async (commentId: number, reset: boolean = false) => {
+    const currentPage = reset ? 0 : replyPage[commentId] || 0;
+    setLoadingReplies((prev) => ({ ...prev, [commentId]: true }));
+
+    const res = await getReplies(commentId, currentPage, 5);
+
+    setReplies((prev) => ({
+      ...prev,
+      [commentId]: reset
+        ? res.content
+        : [...(prev[commentId] || []), ...res.content],
+    }));
+
+    setReplyTotal((prev) => ({ ...prev, [commentId]: res.totalElements }));
+    setReplyPage((prev) => ({ ...prev, [commentId]: currentPage + 1 }));
+    setLoadingReplies((prev) => ({ ...prev, [commentId]: false }));
+  };
+
+  const handleReplySubmit = async (commentId: number) => {
+    if (!replyContent[commentId]?.trim()) return;
+
+    await createComment(dreamId, replyContent[commentId], commentId);
+
+    setReplyContent((prev) => ({ ...prev, [commentId]: '' }));
+    fetchReplies(commentId, true);
+  };
+
+  const handleDelete = async (comment: Comment) => {
+    if (!window.confirm('정말 삭제하시겠습니까?')) return;
+
+    if (user?.role === 'ADMIN' || user?.role === 'MANAGER') {
+      await deleteCommentByAdmin(comment.id);
+    } else {
+      await deleteComment(comment.id);
+    }
+
+    fetchComments();
   };
 
   useEffect(() => {
     fetchComments();
   }, [page, dreamId]);
-
-  const handleDelete = async (commentId: number) => {
-    if (!window.confirm('정말 삭제하시겠습니까?')) return;
-    await deleteComment(dreamId, commentId);
-    fetchComments();
-  };
 
   return (
     <div className="mt-6">
@@ -46,30 +101,104 @@ export default function CommentList({ dreamId }: Props) {
         <p>댓글이 없습니다.</p>
       ) : (
         <ul className="space-y-3">
-          {comments.map((comment) => (
-            <li
-              key={comment.id}
-              className="p-3 rounded bg-base-100 shadow flex justify-between items-center"
-            >
-              <div>
-                <p className="font-semibold">{comment.author.username}</p>
-                <p className="text-sm">{comment.content}</p>
-                <p className="text-xs text-gray-400">
-                  {new Date(comment.createdAt).toLocaleString()}
-                </p>
-              </div>
-              {(user?.id === comment.author.id ||
-                user?.role === 'ADMIN' ||
-                user?.role === 'MANAGER') && (
-                <button
-                  className="btn btn-sm btn-error"
-                  onClick={() => handleDelete(comment.id)}
-                >
-                  삭제
-                </button>
-              )}
-            </li>
-          ))}
+          {comments.map((comment) => {
+            const canDelete =
+              user?.username === comment.author ||
+              user?.role === 'ADMIN' ||
+              user?.role === 'MANAGER';
+            const canReply = user && !comment.isDeleted;
+
+            return (
+              <li key={comment.id} className="p-3 rounded bg-base-100 shadow">
+                <div className="flex justify-between items-center">
+                  <div>
+                    <p className="text-sm">{comment.content}</p>
+                    <p className="text-xs text-gray-400">
+                      {comment.author} |{' '}
+                      {new Date(comment.createdAt).toLocaleString()}
+                      {comment.isDeleted && canDelete && ' (삭제됨)'}
+                    </p>
+                  </div>
+                  {canDelete && (
+                    <button
+                      className="btn btn-sm btn-error"
+                      onClick={() => handleDelete(comment)}
+                    >
+                      삭제
+                    </button>
+                  )}
+                </div>
+
+                {canReply && (
+                  <button
+                    className="ml-0 mt-2 text-blue-500 text-sm"
+                    onClick={() =>
+                      setShowReplyInput((prev) => ({
+                        ...prev,
+                        [comment.id]: !prev[comment.id],
+                      }))
+                    }
+                  >
+                    {showReplyInput[comment.id] ? '입력창 닫기' : '대댓글 달기'}
+                  </button>
+                )}
+
+                {/* 대댓글 입력창 */}
+                {showReplyInput[comment.id] && canReply && (
+                  <div className="mt-2 flex gap-2">
+                    <input
+                      type="text"
+                      value={replyContent[comment.id] || ''}
+                      onChange={(e) =>
+                        setReplyContent((prev) => ({
+                          ...prev,
+                          [comment.id]: e.target.value,
+                        }))
+                      }
+                      placeholder="대댓글 입력..."
+                      className="input input-bordered flex-1"
+                    />
+                    <button
+                      className="btn btn-primary"
+                      onClick={() => handleReplySubmit(comment.id)}
+                    >
+                      작성
+                    </button>
+                  </div>
+                )}
+
+                {replies[comment.id]?.map((reply) => (
+                  <div
+                    key={reply.id}
+                    className="ml-6 mt-2 p-2 border-l border-gray-300"
+                  >
+                    <p className="text-sm">{reply.content}</p>
+                    <p className="text-xs text-gray-400">
+                      {reply.author} |{' '}
+                      {new Date(reply.createdAt).toLocaleString()}
+                      {reply.isDeleted && canDelete && ' (삭제됨)'}
+                    </p>
+                  </div>
+                ))}
+
+                {replyTotal[comment.id] >
+                  (replies[comment.id]?.length || 0) && (
+                  <button
+                    className="ml-6 mt-2 text-blue-500 text-sm"
+                    onClick={() => fetchReplies(comment.id)}
+                    disabled={loadingReplies[comment.id]}
+                  >
+                    {loadingReplies[comment.id]
+                      ? '불러오는 중...'
+                      : `대댓글 더보기 (${
+                          replyTotal[comment.id] -
+                          (replies[comment.id]?.length || 0)
+                        })`}
+                  </button>
+                )}
+              </li>
+            );
+          })}
         </ul>
       )}
       <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />

--- a/src/features/comments/api.ts
+++ b/src/features/comments/api.ts
@@ -12,17 +12,35 @@ export const getComments = async (
   return res.data.data;
 };
 
-export const createComment = async (
-  dreamId: number,
-  content: string,
-): Promise<Comment> => {
-  const res = await api.post(`/dreams/${dreamId}/comments`, { content });
+export const getReplies = async (
+  commentId: number,
+  page: number,
+  size: number,
+): Promise<Page<Comment>> => {
+  const res = await api.get(`/comments/${commentId}/children`, {
+    params: { page, size },
+  });
   return res.data.data;
 };
 
-export const deleteComment = async (
+export const createComment = async (
   dreamId: number,
+  content: string,
+  parentId?: number,
+): Promise<Comment> => {
+  const res = await api.post(`/dreams/${dreamId}/comments`, {
+    content,
+    parentId,
+  });
+  return res.data.data;
+};
+
+export const deleteComment = async (commentId: number): Promise<void> => {
+  await api.delete(`/comments/${commentId}`);
+};
+
+export const deleteCommentByAdmin = async (
   commentId: number,
 ): Promise<void> => {
-  await api.delete(`/dreams/${dreamId}/comments/${commentId}`);
+  await api.delete(`/admin/comments/${commentId}`);
 };

--- a/src/features/comments/api.ts
+++ b/src/features/comments/api.ts
@@ -1,5 +1,5 @@
 import api from '../../lib/axios';
-import type { Comment, Page } from './types';
+import type { Comment, CommentPayload, Page } from './types';
 
 export const getComments = async (
   dreamId: number,
@@ -34,6 +34,14 @@ export const createComment = async (
   });
   return res.data.data;
 };
+
+export async function updateComment(
+  id: number,
+  payload: CommentPayload,
+): Promise<Comment> {
+  const res = await api.put(`/comments/${id}`, payload);
+  return res.data.data;
+}
 
 export const deleteComment = async (commentId: number): Promise<void> => {
   await api.delete(`/comments/${commentId}`);

--- a/src/features/comments/types.ts
+++ b/src/features/comments/types.ts
@@ -1,13 +1,11 @@
 export interface Comment {
   id: number;
   content: string;
-  author: {
-    id: number;
-    username: string;
-    email?: string;
-  };
+  author: string;
   createdAt: string;
   updatedAt?: string;
+  isDeleted?: boolean;
+  totalChildrenCount?: number;
 }
 
 export interface Page<T> {

--- a/src/features/comments/types.ts
+++ b/src/features/comments/types.ts
@@ -1,7 +1,11 @@
 export interface Comment {
   id: number;
   content: string;
-  author: string;
+  author: {
+    id: number;
+    username: string;
+    email: string;
+  };
   createdAt: string;
   updatedAt?: string;
   isDeleted?: boolean;

--- a/src/features/comments/types.ts
+++ b/src/features/comments/types.ts
@@ -19,3 +19,7 @@ export interface Page<T> {
   number: number;
   size: number;
 }
+
+export interface CommentPayload {
+  content: string;
+}

--- a/src/features/dreams/api.ts
+++ b/src/features/dreams/api.ts
@@ -36,11 +36,24 @@ export async function deleteDream(id: number): Promise<void> {
   await api.delete(`/dreams/${id}`);
 }
 
-export async function getAdminDreams(
+export async function getDreamsForAdmin(
   page = 0,
   size = 10,
+  includeDeleted = false,
 ): Promise<Page<Dream>> {
-  const res = await api.get('/admin/dreams', { params: { page, size } });
+  const res = await api.get('/admin/dreams', {
+    params: { page, size, includeDeleted },
+  });
+  return res.data.data;
+}
+
+export async function getDreamAsAdminById(
+  id: number,
+  includeDeleted = false,
+): Promise<Dream> {
+  const res = await api.get(`/admin/dreams/${id}`, {
+    params: { includeDeleted },
+  });
   return res.data.data;
 }
 

--- a/src/features/dreams/types.ts
+++ b/src/features/dreams/types.ts
@@ -3,11 +3,11 @@ export interface Dream {
   title: string;
   content: string;
   dreamDate: string;
-  public?: boolean;
-  author?: {
+  isPublic: boolean;
+  author: {
     id: number;
     username: string;
-    email?: string;
+    email: string;
   };
   deleted?: boolean;
   createdAt?: string;
@@ -18,7 +18,7 @@ export interface DreamPayload {
   title: string;
   content: string;
   dreamDate: string;
-  public?: boolean;
+  isPublic: boolean;
 }
 
 export interface Page<T> {

--- a/src/features/dreams/types.ts
+++ b/src/features/dreams/types.ts
@@ -9,9 +9,10 @@ export interface Dream {
     username: string;
     email: string;
   };
-  deleted?: boolean;
-  createdAt?: string;
+  isDeleted: boolean;
+  createdAt: string;
   updatedAt?: string;
+  authorUsername?: string;
 }
 
 export interface DreamPayload {

--- a/src/pages/admin/AdminDreamDetail.tsx
+++ b/src/pages/admin/AdminDreamDetail.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
+import {
+  deleteDream,
+  deleteDreamByAdmin,
+  getDreamAsAdminById,
+} from '../../features/dreams/api.ts';
+import type { Dream } from '../../features/dreams/types.ts';
+import CommentList from '../../components/CommentList.tsx';
+import CommentForm from '../../components/CommentForm.tsx';
+import { useAuthContext } from '../../features/auth/AuthContext.tsx';
+
+export default function DreamDetail() {
+  const { id } = useParams<{ id: string }>();
+  const dreamId = Number(id);
+  const [dream, setDream] = useState<Dream | null>(null);
+  const [loading, setLoading] = useState(true);
+  const { user } = useAuthContext();
+  const [searchParams] = useSearchParams();
+  const includeDeleted = searchParams.get('includeDeleted') === 'true';
+
+  const fetchDream = () => {
+    setLoading(true);
+    getDreamAsAdminById(Number(id), includeDeleted)
+      .then((res) => setDream(res))
+      .finally(() => setLoading(false));
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm('정말 이 꿈을 삭제하시겠습니까?')) return;
+
+    try {
+      if (user?.role === 'ADMIN' || user?.role === 'MANAGER') {
+        await deleteDreamByAdmin(dreamId);
+      } else {
+        await deleteDream(dreamId);
+      }
+
+      alert('삭제가 완료되었습니다.');
+    } catch (error) {
+      console.error(error);
+      alert('삭제 중 문제가 발생했습니다.');
+    }
+  };
+
+  useEffect(() => {
+    fetchDream();
+  }, [dreamId]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-[50vh]">
+        <span className="loading loading-spinner"></span>
+      </div>
+    );
+  }
+
+  if (!dream) {
+    return <p>해당 꿈을 찾을 수 없습니다.</p>;
+  }
+
+  const isAuthor = user?.id === dream.author.id;
+  const isAdminOrManager = user?.role === 'ADMIN' || user?.role === 'MANAGER';
+
+  return (
+    <div>
+      <h1 className="text-3xl font-bold text-base-content mb-4">
+        {dream.title}{' '}
+        {dream.isDeleted && (
+          <span className="badge badge-error ml-auto">삭제됨</span>
+        )}
+      </h1>
+
+      <div className="card bg-base-100 shadow-md border border-base-300 p-4 mb-4">
+        <div className="flex flex-wrap items-center gap-4 text-sm text-base-content">
+          <div className="flex items-center gap-1">
+            <span className="font-semibold">작성자:</span>
+            <span>{dream.author.username}</span>
+          </div>
+
+          <div className="flex items-center gap-1">
+            <span className="font-semibold">작성일:</span>
+            <span>{dream.createdAt?.slice(0, 10)}</span>
+          </div>
+
+          <div className="flex items-center gap-1">
+            <span className="font-semibold">꿈 일자:</span>
+            <span>{dream.dreamDate}</span>
+          </div>
+
+          <div className="flex items-center gap-1">
+            <span className="font-semibold">공개 여부:</span>
+            <span
+              className={`badge ${
+                dream.isPublic ? 'badge-success' : 'badge-warning'
+              }`}
+            >
+              {dream.isPublic ? '공개' : '비공개'}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="prose max-w-none text-base-content mt-4">
+        <p className="whitespace-pre-wrap">{dream.content}</p>
+      </div>
+
+      {(isAuthor || isAdminOrManager) && (
+        <div className="mt-6 flex gap-2">
+          {isAuthor && (
+            <Link
+              to={`/dreams/${dream.id}/edit`}
+              className="btn btn-primary btn-sm"
+            >
+              수정
+            </Link>
+          )}
+          <button
+            onClick={handleDelete}
+            className="btn btn-error btn-sm"
+            disabled={dream.isDeleted}
+          >
+            삭제
+          </button>
+        </div>
+      )}
+
+      <CommentForm dreamId={dreamId} onSuccess={fetchDream} />
+      <CommentList dreamId={dreamId} />
+    </div>
+  );
+}

--- a/src/pages/admin/MemberDetail.tsx
+++ b/src/pages/admin/MemberDetail.tsx
@@ -98,7 +98,6 @@ export default function MemberDetail() {
 
   return (
     <div className="max-w-3xl mx-auto">
-      {/* Breadcrumb */}
       <div className="breadcrumbs text-sm mb-4">
         <ul>
           <li>
@@ -111,76 +110,64 @@ export default function MemberDetail() {
         </ul>
       </div>
 
-      <div className="card bg-base-100 shadow">
+      <div className="card bg-base-100 shadow-md border border-base-300">
         <div className="card-body">
-          <div className="flex items-center justify-between">
-            <h2 className="card-title">회원 상세</h2>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="card-title text-base-content">회원 상세</h2>
             <Link to="/admin/members" className="btn btn-ghost btn-sm">
               목록으로
             </Link>
           </div>
 
-          {notice && <div className="alert alert-success mb-2">{notice}</div>}
+          {notice && <div className="alert alert-success mb-3">{notice}</div>}
+          {error && <div className="alert alert-error mb-3">{error}</div>}
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-2">
-            <div className="form-control">
-              <label className="label">
-                <span className="label-text">ID</span>
-              </label>
-              <input
-                className="input input-bordered"
-                value={member.id}
-                readOnly
-              />
+          <div className="space-y-4">
+            {/* ID */}
+            <div className="flex flex-col sm:flex-row sm:items-center">
+              <span className="label-text text-base-content font-semibold w-28 shrink-0">
+                ID
+              </span>
+              <p className="text-base-content/70">{member.id}</p>
             </div>
 
-            <div className="form-control">
-              <label className="label">
-                <span className="label-text">사용자명</span>
-              </label>
-              <input
-                className="input input-bordered"
-                value={member.username}
-                readOnly
-              />
+            <div className="flex flex-col sm:flex-row sm:items-center">
+              <span className="label-text text-base-content font-semibold w-28 shrink-0">
+                사용자명
+              </span>
+              <p className="text-base-content/70">{member.username}</p>
             </div>
 
-            <div className="form-control md:col-span-2">
-              <label className="label">
-                <span className="label-text">이메일</span>
-              </label>
-              <input
-                className="input input-bordered"
-                value={member.email ?? ''}
-                readOnly
-              />
+            <div className="flex flex-col sm:flex-row sm:items-center">
+              <span className="label-text text-base-content font-semibold w-28 shrink-0">
+                이메일
+              </span>
+              <p className="text-base-content/70">{member.email ?? '-'}</p>
             </div>
 
-            <div className="form-control">
-              <label className="label">
-                <span className="label-text">생성일</span>
-              </label>
-              <input
-                className="input input-bordered"
-                value={
-                  member.createdAt
-                    ? new Date(member.createdAt).toLocaleString()
-                    : '-'
-                }
-                readOnly
-              />
+            <div className="flex flex-col sm:flex-row sm:items-center">
+              <span className="label-text text-base-content font-semibold w-28 shrink-0">
+                생성일
+              </span>
+              <p className="text-base-content/70">
+                {member.createdAt
+                  ? new Date(member.createdAt).toLocaleString()
+                  : '-'}
+              </p>
             </div>
           </div>
 
-          {/* 권한 변경 */}
-          <div className="divider" />
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
+          <div className="divider my-6" />
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-5 items-end">
             <div className="form-control md:col-span-2">
-              <label className="label">
-                <span className="label-text">권한(Role)</span>
+              <label className="label pb-1">
+                <span className="label-text text-base-content font-semibold">
+                  권한(Role)
+                </span>
               </label>
               <select
-                className="select select-bordered"
+                className="select select-bordered select-sm ml-2"
                 value={roleDraft}
                 onChange={(e) => setRoleDraft(e.target.value as Role)}
                 disabled={saving || isSelf}
@@ -189,7 +176,7 @@ export default function MemberDetail() {
                 <option value="MANAGER">MANAGER</option>
               </select>
               {isSelf && (
-                <label className="label">
+                <label className="label mt-1">
                   <span className="label-text-alt text-warning">
                     자기 자신의 권한 변경은 허용되지 않습니다.
                   </span>
@@ -198,7 +185,7 @@ export default function MemberDetail() {
             </div>
 
             <button
-              className="btn btn-primary"
+              className="btn btn-primary btn-sm mt-6 md:mt-0"
               onClick={handleRoleSave}
               disabled={saving || isSelf || roleDraft === member?.role}
             >

--- a/src/pages/dreams/DreamDetail.tsx
+++ b/src/pages/dreams/DreamDetail.tsx
@@ -69,6 +69,15 @@ export default function DreamDetail() {
       <p className="text-gray-500 text-sm">{dream.createdAt?.slice(0, 10)}</p>
 
       <p className="mt-4">꿈 일자 : {dream.dreamDate}</p>
+      <span
+        className={`badge ${
+          dream.isPublic ? 'badge-success' : 'badge-warning'
+        }`}
+      >
+        {dream.isPublic ? '공개' : '비공개'}
+      </span>
+
+      {dream.isDeleted && <span className="badge badge-error">삭제됨</span>}
       <p className="mt-4">{dream.content}</p>
 
       {(isAuthor || isAdminOrManager) && (
@@ -81,7 +90,11 @@ export default function DreamDetail() {
               수정
             </Link>
           )}
-          <button onClick={handleDelete} className="btn btn-error btn-sm">
+          <button
+            onClick={handleDelete}
+            className="btn btn-error btn-sm"
+            disabled={dream.isDeleted}
+          >
             삭제
           </button>
         </div>

--- a/src/pages/dreams/DreamDetail.tsx
+++ b/src/pages/dreams/DreamDetail.tsx
@@ -56,32 +56,58 @@ export default function DreamDetail() {
   }
 
   if (!dream) {
-    return <p>해당 꿈을 찾을 수 없습니다.</p>;
+    return <p className="text-base-content">해당 꿈을 찾을 수 없습니다.</p>;
   }
 
   const isAuthor = user?.id === dream.author.id;
   const isAdminOrManager = user?.role === 'ADMIN' || user?.role === 'MANAGER';
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold">{dream.title}</h1>
-      <p className="text-gray-500">{dream.author.username}</p>
-      <p className="text-gray-500 text-sm">{dream.createdAt?.slice(0, 10)}</p>
+    <div className="max-w-3xl mx-auto p-6 space-y-6">
+      <h1 className="text-3xl font-bold text-base-content">{dream.title}</h1>
 
-      <p className="mt-4">꿈 일자 : {dream.dreamDate}</p>
-      <span
-        className={`badge ${
-          dream.isPublic ? 'badge-success' : 'badge-warning'
-        }`}
-      >
-        {dream.isPublic ? '공개' : '비공개'}
-      </span>
+      <div className="card bg-base-100 shadow-md border border-base-300 p-4">
+        <div className="flex flex-wrap items-center gap-4 text-sm text-base-content">
+          <div className="flex items-center gap-1">
+            <span className="font-semibold">작성자:</span>
+            <span className="text-base-content">{dream.author.username}</span>
+          </div>
 
-      {dream.isDeleted && <span className="badge badge-error">삭제됨</span>}
-      <p className="mt-4">{dream.content}</p>
+          <div className="flex items-center gap-1">
+            <span className="font-semibold">작성일:</span>
+            <span className="text-base-content">
+              {dream.createdAt?.slice(0, 10)}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-1">
+            <span className="font-semibold">꿈 일자:</span>
+            <span className="text-base-content">{dream.dreamDate}</span>
+          </div>
+
+          <div className="flex items-center gap-1">
+            <span className="font-semibold">공개 여부:</span>
+            <span
+              className={`badge ${
+                dream.isPublic ? 'badge-success' : 'badge-warning'
+              }`}
+            >
+              {dream.isPublic ? '공개' : '비공개'}
+            </span>
+          </div>
+
+          {dream.isDeleted && (
+            <span className="badge badge-error ml-auto">삭제됨</span>
+          )}
+        </div>
+      </div>
+
+      <div className="prose max-w-none text-base-content">
+        <p className="whitespace-pre-wrap">{dream.content}</p>
+      </div>
 
       {(isAuthor || isAdminOrManager) && (
-        <div className="mt-6 flex gap-2">
+        <div className="flex gap-2 mt-6">
           {isAuthor && (
             <Link
               to={`/dreams/${dream.id}/edit`}

--- a/src/pages/dreams/DreamDetail.tsx
+++ b/src/pages/dreams/DreamDetail.tsx
@@ -1,21 +1,46 @@
 import { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
-import { getDreamById } from '../../features/dreams/api.ts';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import {
+  deleteDream,
+  deleteDreamByAdmin,
+  getDreamById,
+} from '../../features/dreams/api.ts';
 import type { Dream } from '../../features/dreams/types.ts';
 import CommentList from '../../components/CommentList.tsx';
 import CommentForm from '../../components/CommentForm.tsx';
+import { useAuthContext } from '../../features/auth/AuthContext.tsx';
 
 export default function DreamDetail() {
   const { id } = useParams<{ id: string }>();
   const dreamId = Number(id);
   const [dream, setDream] = useState<Dream | null>(null);
   const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+  const { user } = useAuthContext();
 
   const fetchDream = () => {
     setLoading(true);
     getDreamById(dreamId)
       .then((res) => setDream(res))
       .finally(() => setLoading(false));
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm('정말 이 꿈을 삭제하시겠습니까?')) return;
+
+    try {
+      if (user?.role === 'ADMIN' || user?.role === 'MANAGER') {
+        await deleteDreamByAdmin(dreamId);
+      } else {
+        await deleteDream(dreamId);
+      }
+
+      alert('삭제가 완료되었습니다.');
+      navigate('/dreams');
+    } catch (error) {
+      console.error(error);
+      alert('삭제 중 문제가 발생했습니다.');
+    }
   };
 
   useEffect(() => {
@@ -34,20 +59,33 @@ export default function DreamDetail() {
     return <p>해당 꿈을 찾을 수 없습니다.</p>;
   }
 
+  const isAuthor = user?.id === dream.author.id;
+  const isAdminOrManager = user?.role === 'ADMIN' || user?.role === 'MANAGER';
+
   return (
     <div>
       <h1 className="text-2xl font-bold">{dream.title}</h1>
-      <p className="text-gray-500">{dream.dreamDate}</p>
+      <p className="text-gray-500">{dream.author.username}</p>
+      <p className="text-gray-500 text-sm">{dream.createdAt?.slice(0, 10)}</p>
+
+      <p className="mt-4">꿈 일자 : {dream.dreamDate}</p>
       <p className="mt-4">{dream.content}</p>
 
-      <div className="mt-6">
-        <Link
-          to={`/dreams/${dream.id}/edit`}
-          className="btn btn-primary btn-sm"
-        >
-          수정
-        </Link>
-      </div>
+      {(isAuthor || isAdminOrManager) && (
+        <div className="mt-6 flex gap-2">
+          {isAuthor && (
+            <Link
+              to={`/dreams/${dream.id}/edit`}
+              className="btn btn-primary btn-sm"
+            >
+              수정
+            </Link>
+          )}
+          <button onClick={handleDelete} className="btn btn-error btn-sm">
+            삭제
+          </button>
+        </div>
+      )}
 
       <CommentForm dreamId={dreamId} onSuccess={fetchDream} />
       <CommentList dreamId={dreamId} />

--- a/src/pages/dreams/DreamEditor.tsx
+++ b/src/pages/dreams/DreamEditor.tsx
@@ -2,6 +2,8 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import api from '../../lib/axios.ts';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
+import { createDream, updateDream } from '../../features/dreams/api.ts';
+import type { DreamPayload } from '../../features/dreams/types.ts';
 
 export default function DreamEditor({ mode }: { mode: 'create' | 'edit' }) {
   const { id } = useParams();
@@ -20,7 +22,7 @@ export default function DreamEditor({ mode }: { mode: 'create' | 'edit' }) {
     queryKey: ['dream', id],
     queryFn: async () => {
       const { data } = await api.get(`/dreams/${id}`);
-      return data;
+      return data.data;
     },
   });
 
@@ -34,19 +36,11 @@ export default function DreamEditor({ mode }: { mode: 'create' | 'edit' }) {
   }, [data, mode]);
 
   const mutate = useMutation({
-    mutationFn: (input: any) =>
-      mode === 'create'
-        ? api.post('/dreams', input).then((res) => res.data)
-        : api.put(`/dreams/${id}`, input).then((res) => res.data),
+    mutationFn: (input: DreamPayload) =>
+      mode === 'create' ? createDream(input) : updateDream(Number(id), input),
     onSuccess: (d) => {
       qc.invalidateQueries({ queryKey: ['myDreams'] });
-
-      const dreamId = d?.id ?? d?.data?.id;
-      if (dreamId) {
-        nav(`/dreams/${dreamId}`);
-      } else {
-        nav('/dreams');
-      }
+      nav(`/dreams/${d.id}`);
     },
   });
 

--- a/src/pages/dreams/Dreams.tsx
+++ b/src/pages/dreams/Dreams.tsx
@@ -51,9 +51,11 @@ export default function Dreams() {
                 to={`/dreams/${dream.id}`}
                 className="text-xl font-semibold hover:underline"
               >
-                {dream.title}
+                [{dream.dreamDate}] {dream.title}
               </Link>
-              <p className="text-sm text-gray-500">{dream.dreamDate}</p>
+              <p className="text-sm text-gray-500">
+                {dream.createdAt.slice(0, 10)} | {dream.authorUsername}
+              </p>
             </li>
           ))}
         </ul>

--- a/src/pages/dreams/MyDreams.tsx
+++ b/src/pages/dreams/MyDreams.tsx
@@ -50,9 +50,11 @@ export default function MyDreams() {
                 to={`/dreams/${dream.id}`}
                 className="text-xl font-semibold"
               >
-                {dream.title}
+                [{dream.dreamDate}] {dream.title}
               </Link>
-              <p className="text-sm text-gray-500">{dream.dreamDate}</p>
+              <p className="text-sm text-gray-500">
+                {dream.createdAt.slice(0, 10)} | {dream.authorUsername}
+              </p>
             </li>
           ))}
         </ul>

--- a/src/pages/dreams/MyDreams.tsx
+++ b/src/pages/dreams/MyDreams.tsx
@@ -2,13 +2,16 @@ import { useEffect, useState } from 'react';
 import { getMyDreams } from '../../features/dreams/api';
 import type { Dream } from '../../features/dreams/types';
 import Pagination from '../../components/ui/Pagination';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuthContext } from '../../features/auth/AuthContext.tsx';
 
 export default function MyDreams() {
   const [dreams, setDreams] = useState<Dream[]>([]);
   const [page, setPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [loading, setLoading] = useState(true);
+  const nav = useNavigate();
+  const { user } = useAuthContext();
 
   useEffect(() => {
     setLoading(true);
@@ -22,7 +25,17 @@ export default function MyDreams() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">내 꿈 목록</h1>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-bold mb-4">내 꿈 목록</h1>
+        {user && (
+          <button
+            className="btn btn-primary"
+            onClick={() => nav('/dreams/new')}
+          >
+            + 꿈일기 작성
+          </button>
+        )}
+      </div>
       {loading ? (
         <div className="flex justify-center items-center">
           <span className="loading loading-spinner loading-lg"></span>


### PR DESCRIPTION
다음 내용들을 구현:
- 댓글, 대댓글 관련 ui 수정
	- 삭제된 댓글에 대해 대댓글 입력 폼 비활성화
	- 대댓글 입력 폼 버튼으로 열고 닫도록 수정
	- 대댓글 페이징 적용
- 꿈일기 관련 ui 수정
	- 관리자, 또는 작성자에게만 표시되는 꿈일기 삭제 버튼 구현
	- 내 꿈일기 목록에 꿈일기 작성 버튼 추가
	- 꿈일기 목록에 꿈 일자, 작성자 표시하도록 수정
	- 꿈일기 상세 페이지에 공개/비공개 여부, 삭제 여부 표시하도록 추가
- 댓글, 대댓글 관련 기능 추가
	- 대댓글 삭제 기능, 댓글 수정 기능 추가
- 관리자용 꿈일기 상세 조회 페이지 분리