### PR TITLE
feat: 프론트엔드 자동 배포를 위한 GitHub Actions 워크플로우 구축

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,85 @@
+name: Deploy Frontend (prod)
+
+on:
+  workflow_dispatch: { }
+  push:
+    branches: [ main ]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'pnpm-lock.yaml'
+      - 'yarn.lock'
+      - 'vite.config.*'
+      - 'next.config.*'
+      - 'public/**'
+      - 'src/**'
+
+concurrency:
+  group: somniverse-prod-frontend
+  cancel-in-progress: false
+
+env:
+  REMOTE_HOST: ${{ secrets.DEPLOY_HOST }}
+  REMOTE_USER: ${{ secrets.DEPLOY_USER }}
+  REMOTE_PORT: ${{ secrets.DEPLOY_SSH_PORT }}
+  REMOTE_DIR: /srv/somniverse
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://somniverse.kro.kr
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Archive build
+        run: |
+          tar -C dist -czf dist.tgz .
+
+      - name: Prepare SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -p "${{ env.REMOTE_PORT || 22 }}" -H "${{ env.REMOTE_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Upload artifact
+        run: |
+          scp -P "${{ env.REMOTE_PORT || 22 }}" dist.tgz \
+            "${{ env.REMOTE_USER }}"@"${{ env.REMOTE_HOST }}":"${{ env.REMOTE_DIR }}/releases/frontend-dist.tgz"
+
+      - name: Backup & swap build on server
+        run: |
+          ssh -p "${{ env.REMOTE_PORT || 22 }}" "${{ env.REMOTE_USER }}"@"${{ env.REMOTE_HOST }}" << 'EOF'
+          set -euo pipefail
+          mkdir -p /srv/somniverse/releases
+          mkdir -p /srv/somniverse/frontend/dist
+          ts=$(date +%Y%m%d%H%M%S)
+
+          if [ -d /srv/somniverse/frontend/dist ]; then
+            tar -C /srv/somniverse/frontend -czf "/srv/somniverse/releases/frontend-$ts.tgz" dist || true
+          fi
+
+          rm -rf /srv/somniverse/frontend/dist/*
+          tar -C /srv/somniverse/frontend/dist -xzf /srv/somniverse/releases/frontend-dist.tgz
+          rm -f /srv/somniverse/releases/frontend-dist.tgz
+          EOF
+
+      - name: Smoke test over HTTPS
+        run: |
+          curl -fsS "https://somniverse.kro.kr/" | head -c 1000 >/dev/null


### PR DESCRIPTION
- **GitHub Actions 워크플로우 추가** (`.github/workflows/deploy-frontend.yml`)
  - 프론트엔드 관련 파일(`src/**`, `package.json` 등)이 `main` 브랜치에 푸시될 때만 워크플로우가 실행되도록 트리거 경로를 설정
  - **Node.js 22** 환경에서 `npm ci`를 통해 의존성을 설치하고, `npm run build` 스크립트로 프로덕션 빌드를 수행
  - 빌드 결과물(`dist` 디렉토리)을 `tar.gz` 형식으로 압축하여 업로드 시간을 최소화
  - 원격 서버의 `/srv/somniverse/releases` 경로로 압축된 빌드 파일을 안전하게 전송

- **안전한 배포 및 백업 전략 구현** (원격 서버 스크립트)
  - 배포 직전, 현재 운영 중인 `dist` 디렉토리 전체를 타임스탬프가 찍힌 압축 파일로 `/srv/somniverse/releases`에 백업
  - 기존 `dist` 디렉토리의 내용을 비운 뒤, 새로 업로드된 파일의 압축을 풀어 새 버전으로 교체
  - 배포 완료 후 간단한 `curl` 명령으로 **Smoke Test**를 수행하여 사이트가 정상적으로 응답하는지 확인