### PR TITLE
 feat: 꿈일기 AI 감정 분석 UI 배포

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,13 @@
       "name": "somniverse-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "24": "^0.0.0",
         "@tanstack/react-query": "^5.85.5",
         "axios": "^1.11.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-icons": "^5.5.0",
-        "react-router-dom": "^7.8.1"
+        "react-router-dom": "^7.12.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -21,7 +22,7 @@
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
-        "daisyui": "^5.0.50",
+        "daisyui": "^5.5.14",
         "eslint": "^9.33.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
@@ -30,7 +31,7 @@
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
         "prettier": "^3.6.2",
-        "tailwindcss": "^4.1.12",
+        "tailwindcss": "^4.1.18",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.39.1",
         "vite": "^7.1.2"
@@ -1411,6 +1412,12 @@
         "tailwindcss": "4.1.12"
       }
     },
+    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.12.tgz",
+      "integrity": "sha512-DzFtxOi+7NsFf7DBtI3BJsynR+0Yp6etH+nRPTbpWnS2pZBaSksv/JGctNwSWzbFjp0vxSqknaUylseZqMDGrA==",
+      "dev": true
+    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.12.tgz",
@@ -1671,6 +1678,12 @@
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
       }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/tailwindcss": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.12.tgz",
+      "integrity": "sha512-DzFtxOi+7NsFf7DBtI3BJsynR+0Yp6etH+nRPTbpWnS2pZBaSksv/JGctNwSWzbFjp0vxSqknaUylseZqMDGrA==",
+      "dev": true
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.85.5",
@@ -2068,6 +2081,11 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/24": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/24/-/24-0.0.0.tgz",
+      "integrity": "sha512-dgRd1Jm77CFbawoAu4/37jJCl4LjQVzfACgUVyGeN7OG1qHKsEeTEyvPvzsK0FF59F/uJ1eq2wsrO+U+Sa028Q=="
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -2531,12 +2549,15 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
-      "license": "MIT",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {
@@ -2562,11 +2583,10 @@
       "license": "MIT"
     },
     "node_modules/daisyui": {
-      "version": "5.0.50",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.0.50.tgz",
-      "integrity": "sha512-c1PweK5RI1C76q58FKvbS4jzgyNJSP6CGTQ+KkZYzADdJoERnOxFoeLfDHmQgxLpjEzlYhFMXCeodQNLCC9bow==",
+      "version": "5.5.14",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.5.14.tgz",
+      "integrity": "sha512-L47rvw7I7hK68TA97VB8Ee0woHew+/ohR6Lx6Ah/krfISOqcG4My7poNpX5Mo5/ytMxiR40fEaz6njzDi7cuSg==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/saadeghi/daisyui?sponsor=1"
       }
@@ -5157,10 +5177,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.1.tgz",
-      "integrity": "sha512-5cy/M8DHcG51/KUIka1nfZ2QeylS4PJRs6TT8I4PF5axVsI5JUxp0hC0NZ/AEEj8Vw7xsEoD7L/6FY+zoYaOGA==",
-      "license": "MIT",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
+      "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -5179,12 +5198,11 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.1.tgz",
-      "integrity": "sha512-NkgBCF3sVgCiAWIlSt89GR2PLaksMpoo3HDCorpRfnCEfdtRPLiuTf+CNXvqZMI5SJLZCLpVCvcZrTdtGW64xQ==",
-      "license": "MIT",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.12.0.tgz",
+      "integrity": "sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==",
       "dependencies": {
-        "react-router": "7.8.1"
+        "react-router": "7.12.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5413,10 +5431,9 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-      "license": "MIT"
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -5744,11 +5761,10 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.12.tgz",
-      "integrity": "sha512-DzFtxOi+7NsFf7DBtI3BJsynR+0Yp6etH+nRPTbpWnS2pZBaSksv/JGctNwSWzbFjp0vxSqknaUylseZqMDGrA==",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
+      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+      "dev": true
     },
     "node_modules/tapable": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "24": "^0.0.0",
     "@tanstack/react-query": "^5.85.5",
     "axios": "^1.11.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-icons": "^5.5.0",
-    "react-router-dom": "^7.8.1"
+    "react-router-dom": "^7.12.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
@@ -23,7 +24,7 @@
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
-    "daisyui": "^5.0.50",
+    "daisyui": "^5.5.14",
     "eslint": "^9.33.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
@@ -32,7 +33,7 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
     "prettier": "^3.6.2",
-    "tailwindcss": "^4.1.12",
+    "tailwindcss": "^4.1.18",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
     "vite": "^7.1.2"

--- a/src/features/dreams/types.ts
+++ b/src/features/dreams/types.ts
@@ -13,6 +13,8 @@ export interface Dream {
   createdAt: string;
   updatedAt?: string;
   authorUsername?: string;
+  analysisStatus: string;
+  emotion?: string;
 }
 
 export interface DreamPayload {

--- a/src/pages/dreams/DreamDetail.tsx
+++ b/src/pages/dreams/DreamDetail.tsx
@@ -96,6 +96,13 @@ export default function DreamDetail() {
             </span>
           </div>
 
+          <div className="flex items-center gap-1">
+            <span className="font-semibold">감정:</span>
+            <span className="badge badge-info">
+              {dream.emotion ? dream.emotion : dream.analysisStatus}
+            </span>
+          </div>
+
           {dream.isDeleted && (
             <span className="badge badge-error ml-auto">삭제됨</span>
           )}

--- a/src/pages/dreams/Dreams.tsx
+++ b/src/pages/dreams/Dreams.tsx
@@ -65,12 +65,12 @@ export default function Dreams() {
             <li key={dream.id} className="card bg-base-100 shadow-md p-4">
               <Link
                 to={`/dreams/${dream.id}`}
-                className="text-xl font-semibold hover:underline"
+                className="text-xl font-semibold hover:unde rline"
               >
                 [{dream.dreamDate}] {dream.title}
               </Link>
               <p className="text-sm text-gray-500">
-                {dream.createdAt.slice(0, 10)} | {dream.authorUsername}
+                {dream.createdAt.slice(0, 10)} | {dream.authorUsername} | {dream.emotion}
               </p>
             </li>
           ))}

--- a/src/pages/dreams/MyDreams.tsx
+++ b/src/pages/dreams/MyDreams.tsx
@@ -69,7 +69,8 @@ export default function MyDreams() {
                 [{dream.dreamDate}] {dream.title}
               </Link>
               <p className="text-sm text-gray-500">
-                {dream.createdAt.slice(0, 10)} | {dream.authorUsername}
+                {dream.createdAt.slice(0, 10)} | {dream.authorUsername} |{' '}
+                {dream.emotion}
               </p>
             </li>
           ))}


### PR DESCRIPTION
### 작업 개요
사용자가 작성한 꿈일기의 감정을 AI가 분석하여 보여주는 UI 기능을 배포합니다.
이제 사용자는 꿈일기 목록과 상세 화면에서 자신의 꿈이 어떤 감정으로 해석되었는지 시각적으로 확인할 수 있습니다.

---

### 주요 변경 사항
1) 감정 분석 결과 표시
- 꿈일기 제목 옆에 분석된 감정(예: '기쁨', '불안')이 태그 형태로 표시됩니다.
- 분석이 진행 중인 경우, 분석 상태(분석 대기)를 표시합니다.

2) 페이지 적용 범위
- '나의 꿈일기' 목록
- '공개된 꿈일기' 목록
- 꿈일기 상세 보기 페이지